### PR TITLE
Fixed #5 graceful exit throws an exception

### DIFF
--- a/src/Backend/Backend.Api/GraphQL/Mutation.cs
+++ b/src/Backend/Backend.Api/GraphQL/Mutation.cs
@@ -10,8 +10,8 @@ public record JoinedChannel(string Channel)
 public class Mutation
 {
     public async Task<JoinedChannel> JoinChannel(
-    ChatService service,
-    string channel)
+        ChatService service,
+        string channel)
     {
         await service.JoinChannelAsync(channel.ToLowerInvariant());
 


### PR DESCRIPTION
Was passing along cancellation token to write message unto database, which in turn would enforce a full stop of current operation. And hence throwing an exception.

For now we'll just let the application be done with writing any messages in buffer and then just exit. In the future we might want to allow cancellation of this operation, but for now this is enough.

Ref: https://github.com/asabla/ChatKnut/issues/5