### PR TITLE
Support for subscriptions when inserting chat messages

### DIFF
--- a/src/Backend/Backend.Api/Backend.Api.csproj
+++ b/src/Backend/Backend.Api/Backend.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="12.15.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.15.1" />
     <PackageReference Include="HotChocolate.Data.EntityFramework" Version="12.15.1" />
     <PackageReference Include="HotChocolate.PersistedQueries.InMemory" Version="12.15.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">

--- a/src/Backend/Backend.Api/GraphQL/Mutation.cs
+++ b/src/Backend/Backend.Api/GraphQL/Mutation.cs
@@ -1,4 +1,6 @@
 using ChatKnut.Common.TwitchChat;
+using ChatKnut.Data.Chat;
+using ChatKnut.Data.Chat.Models;
 
 namespace ChatKnut.Backend.Api.GraphQL;
 
@@ -16,5 +18,47 @@ public class Mutation
         await service.JoinChannelAsync(channel.ToLowerInvariant());
 
         return new JoinedChannel(channel);
+    }
+
+    public async Task<Channel> ChangeAutoJoinChannel(
+        [ScopedService] ChatKnutDbContext context,
+        string channelName,
+        bool autoJoin)
+    {
+        if (string.IsNullOrWhiteSpace(channelName))
+            throw new ArgumentNullException(nameof(channelName));
+
+        var channel = context.Channels
+            .Where(x => x.ChannelName.Equals(channelName.ToLowerInvariant()))
+            .FirstOrDefault();
+
+        if (channel is null)
+            throw new Exception($"Channel '{channelName}' was not found");
+
+        channel.AutoJoin = autoJoin;
+
+        await context.SaveChangesAsync();
+
+        return channel;
+    }
+
+    public async Task<IEnumerable<JoinedChannel>> JoinAllChannels(
+        [ScopedService] ChatKnutDbContext context,
+        ChatService service)
+    {
+        var result = new List<JoinedChannel>();
+        var channels = context.Channels
+            .Select(x => new { x.Id, x.ChannelName })
+            .ToList();
+
+        foreach (var chan in channels)
+        {
+            await service.JoinChannelAsync($"#{chan.ChannelName}");
+            result.Add(new(chan.ChannelName));
+
+            await Task.Delay(100);
+        }
+
+        return result;
     }
 }

--- a/src/Backend/Backend.Api/GraphQL/Subscription.cs
+++ b/src/Backend/Backend.Api/GraphQL/Subscription.cs
@@ -1,0 +1,12 @@
+using ChatKnut.Data.Chat.Models;
+
+namespace ChatKnut.Backend.Api.GraphQL;
+
+public class Subscription
+{
+    [Subscribe]
+    public ChatMessage ChatMessageReceived(
+        [Topic] string channelName,
+        [EventMessage] ChatMessage message)
+        => message;
+}

--- a/src/Backend/Backend.Api/Program.cs
+++ b/src/Backend/Backend.Api/Program.cs
@@ -16,8 +16,6 @@ builder.Services.AddPooledDbContextFactory<ChatKnutDbContext>(options
 // Caching things
 builder.Services
     .AddMemoryCache();
-builder.Services
-    .AddInMemorySubscriptions();
 
 // Background service setup
 builder.Services
@@ -29,6 +27,11 @@ builder.Services
 builder.Services
     .AddGraphQLServer()
         .InitializeOnStartup()
+        .ModifyRequestOptions(opt =>
+        {
+            opt.Complexity.Enable = true;
+            opt.Complexity.MaximumAllowed = 1500;
+        })
         .RegisterDbContext<ChatKnutDbContext>(DbContextKind.Pooled)
         .RegisterService<ChatService>()
         .SetPagingOptions(new PagingOptions
@@ -40,6 +43,8 @@ builder.Services
     .AddProjections()
     .AddQueryType<Query>()
     .AddMutationType<Mutation>()
+    .AddSubscriptionType<Subscription>()
+        .AddInMemorySubscriptions()
     .AddInMemoryQueryStorage()
     .UseAutomaticPersistedQueryPipeline();
 

--- a/src/Common/Common.TwitchChat/Common.TwitchChat.csproj
+++ b/src/Common/Common.TwitchChat/Common.TwitchChat.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HotChocolate.Subscriptions" Version="12.15.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/Data/Data.Chat/Migrations/20221108101933_InitialSetup.Designer.cs
+++ b/src/Data/Data.Chat/Migrations/20221108101933_InitialSetup.Designer.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Data.Chat.Migrations
 {
     [DbContext(typeof(ChatKnutDbContext))]
-    [Migration("20221105192525_InitialSetup")]
+    [Migration("20221108101933_InitialSetup")]
     partial class InitialSetup
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -24,6 +24,9 @@ namespace Data.Chat.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("TEXT");
+
+                    b.Property<bool>("AutoJoin")
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ChannelName")
                         .IsRequired()

--- a/src/Data/Data.Chat/Migrations/20221108101933_InitialSetup.cs
+++ b/src/Data/Data.Chat/Migrations/20221108101933_InitialSetup.cs
@@ -15,7 +15,8 @@ namespace Data.Chat.Migrations
                 {
                     Id = table.Column<Guid>(type: "TEXT", nullable: false),
                     ChannelName = table.Column<string>(type: "TEXT", nullable: false),
-                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    AutoJoin = table.Column<bool>(type: "INTEGER", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/Data/Data.Chat/Migrations/ChatKnutDbContextModelSnapshot.cs
+++ b/src/Data/Data.Chat/Migrations/ChatKnutDbContextModelSnapshot.cs
@@ -23,6 +23,9 @@ namespace Data.Chat.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("TEXT");
 
+                    b.Property<bool>("AutoJoin")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("ChannelName")
                         .IsRequired()
                         .HasColumnType("TEXT");

--- a/src/Data/Data.Chat/Models/Channel.cs
+++ b/src/Data/Data.Chat/Models/Channel.cs
@@ -11,6 +11,8 @@ public class Channel
 
     public DateTime CreatedUtc { get; set; }
 
+    public bool AutoJoin { get; set; } = false;
+
     public ICollection<ChatMessage> Messages { get; set; }
         = new List<ChatMessage>();
 }


### PR DESCRIPTION
These changes will do two things
- Add support for subscriptions through GraphQL endpoint
- Re-creating migrations due to model changes